### PR TITLE
Support for FreeStyle SVG when exporting Vector

### DIFF
--- a/measureit_arch_baseclass.py
+++ b/measureit_arch_baseclass.py
@@ -17,6 +17,13 @@ def has_dimension_generator(context):
     hasattr(context.object, "DimensionGenerator") and \
     len(context.object.DimensionGenerator) > 0
 
+def freestyle_update_flag(self, context):
+    scene = context.scene
+    sceneProps= scene.MeasureItArchProps
+    if  sceneProps.embed_freestyle_svg:
+        scene.render.use_freestyle = sceneProps.embed_freestyle_svg
+        scene.svg_export.use_svg_export = sceneProps.embed_freestyle_svg
+
 
 def update_active_dim(self,context):
     if has_dimension_generator(context):
@@ -432,6 +439,11 @@ class MeasureItARCHSceneProps(PropertyGroup):
     embed_scene_render: BoolProperty(name="Embed Scene Render",
                             description="Render the scene and automatically combine the rendered image with the Measureit-ARCH render pass",
                             default=False)
+    
+    embed_freestyle_svg: BoolProperty(name="Embed Freestyle SVG",
+                        description="Render a Freestyle SVG and automatically combine the rendered image with the Measureit-ARCH render pass \n Note: Requires 'Render: Freestyle SVG Export' addon to be enabled",
+                        default=False,
+                        update=freestyle_update_flag)
 
     default_scale: IntProperty(name='Default Paper Scale', min=1, default=25,
                                 description="Default Paper Scale (used for font sizing)")

--- a/measureit_arch_baseclass.py
+++ b/measureit_arch_baseclass.py
@@ -444,6 +444,13 @@ class MeasureItARCHSceneProps(PropertyGroup):
                         description="Render a Freestyle SVG and automatically combine the rendered image with the Measureit-ARCH render pass \n Note: Requires 'Render: Freestyle SVG Export' addon to be enabled",
                         default=False,
                         update=freestyle_update_flag)
+    
+    keep_freestyle_svg: BoolProperty(name="Keep Freestyle SVG",
+                        description="When Embeding a Freestyle SVG, keep the generated Freestyle SVG as a seperate file as well",
+                        default=False,
+                        update=freestyle_update_flag)
+                        
+
 
     default_scale: IntProperty(name='Default Paper Scale', min=1, default=25,
                                 description="Default Paper Scale (used for font sizing)")

--- a/measureit_arch_geometry.py
+++ b/measureit_arch_geometry.py
@@ -350,7 +350,7 @@ def draw_hatches(context,myobj, hatchGen, mat, svg=None):
         verts = bm.verts
 
         if True:
-            polys = z_order_faces(polys,myobj)
+            polys = z_order_faces(faces,myobj)
             
         
         matSlots = myobj.material_slots

--- a/measureit_arch_main.py
+++ b/measureit_arch_main.py
@@ -302,6 +302,7 @@ class SCENE_PT_MARCH_Settings(Panel):
         col.prop(sceneProps, "eval_mods")
         col.prop(sceneProps, "use_text_autoplacement")
         col.prop(sceneProps, 'default_resolution', text="Default Resolution")
+        col.prop(sceneProps, 'keep_freestyle_svg', text="Keep Freestyle SVG")
         
         col = layout.column(align = True, heading='Debug')
         col.prop(sceneProps, "measureit_arch_debug_text")

--- a/measureit_arch_render.py
+++ b/measureit_arch_render.py
@@ -496,6 +496,12 @@ def render_main_svg(self, context, animation=False):
         # and embed the output in the final SVG.
         freestyle_svg_export = 'render_freestyle_svg' in get_loaded_addons()
 
+        # -----------------------------
+        # Loop to draw all objects
+        # -----------------------------
+        draw3d_loop(context,objlist,svg=svg)
+        draw_titleblock(context,svg=svg)
+
         if freestyle_svg_export:
             scene.render.use_freestyle = True
             scene.svg_export.mode = 'FRAME'
@@ -529,11 +535,7 @@ def render_main_svg(self, context, animation=False):
         # TODO: we may want to restore other scene modifications too
         scene.render.image_settings.file_format = lastformat
 
-    # -----------------------------
-    # Loop to draw all objects
-    # -----------------------------
-    draw3d_loop(context,objlist,svg=svg)
-    draw_titleblock(context,svg=svg)
+
 
  
 

--- a/measureit_arch_render.py
+++ b/measureit_arch_render.py
@@ -532,12 +532,15 @@ def render_main_svg(self, context, animation=False):
             scene.render.use_freestyle = True
             scene.svg_export.use_svg_export = True
             scene.svg_export.mode = 'FRAME'
-
+        
+        base_path = bpy.context.scene.render.filepath
+        bpy.context.scene.render.filepath += '_freestyle_'
         scene.render.image_settings.file_format = 'PNG'
         scene.render.use_file_extension = True
         bpy.ops.render.render(write_still=False)
 
         image_path = bpy.context.scene.render.filepath
+       
         if freestyle_svg_export:
             frame = scene.frame_current
             svg_image_path = bpy.path.abspath("{}{:04d}.svg".format(image_path, frame))
@@ -545,13 +548,15 @@ def render_main_svg(self, context, animation=False):
             for elem in svg_root:
                 svg.add(SVGWriteElement(elem))
             # TODO: should we delete file `svg_image_path`?
+            if os.path.exists(svg_image_path) and not sceneProps.keep_freestyle_svg:
+                os.remove(svg_image_path)
        
 
         scene.render.image_settings.file_format = lastformat[0]
         scene.render.use_freestyle = lastformat[1]
         scene.svg_export.use_svg_export = lastformat[2]
         scene.svg_export.mode = lastformat[3]
-
+        bpy.context.scene.render.filepath = base_path
 
 
  

--- a/measureit_arch_render.py
+++ b/measureit_arch_render.py
@@ -527,14 +527,12 @@ def render_main_svg(self, context, animation=False):
         # and embed the output in the final SVG.
         freestyle_svg_export = 'render_freestyle_svg' in get_loaded_addons()
 
+        lastformat = scene.render.image_settings.file_format, scene.render.use_freestyle, scene.svg_export.use_svg_export, scene.svg_export.mode
         if freestyle_svg_export:
             scene.render.use_freestyle = True
-            scene.svg_export.mode = 'FRAME'
             scene.svg_export.use_svg_export = True
-            scene.render.line_thickness_mode = 'ABSOLUTE'
-            scene.render.line_thickness = 1
+            scene.svg_export.mode = 'FRAME'
 
-        lastformat = scene.render.image_settings.file_format
         scene.render.image_settings.file_format = 'PNG'
         scene.render.use_file_extension = True
         bpy.ops.render.render(write_still=False)
@@ -549,8 +547,10 @@ def render_main_svg(self, context, animation=False):
             # TODO: should we delete file `svg_image_path`?
        
 
-        # TODO: we may want to restore other scene modifications too
-        scene.render.image_settings.file_format = lastformat
+        scene.render.image_settings.file_format = lastformat[0]
+        scene.render.use_freestyle = lastformat[1]
+        scene.svg_export.use_svg_export = lastformat[2]
+        scene.svg_export.mode = lastformat[3]
 
 
 


### PR DESCRIPTION
First shot at #147 

The TODO items I've added are open for discussion:
- Do we delete the SVG that FreeStyle created when not needed anymore?
- Would you like to embed the PNG in the SVG?
- Should we restore all changes that we've made to the scene? Maybe create a helper for this...

In general, I've noticed lot's of trailing whitespace. Would you like a PR for that? Maybe use Flake8?

Note: you may need to revert commit 835134404c28b51cedeee2d5e4f303765b01763a (which is included here), at least I needed to because of an error:

```
Python: Traceback (most recent call last):
  File "/home/mp/.config/blender/2.91/scripts/addons/MeasureIt_ARCH/measureit_arch_render.py", line 234, in execute
    if render_main_svg(self, context) is True:
  File "/home/mp/.config/blender/2.91/scripts/addons/MeasureIt_ARCH/measureit_arch_render.py", line 531, in render_main_svg
    draw3d_loop(context,objlist,svg=svg)
  File "/home/mp/.config/blender/2.91/scripts/addons/MeasureIt_ARCH/measureit_arch_geometry.py", line 3618, in draw3d_loop
    draw_hatches(context,myobj,scene.HatchGenerator,mat,svg=svg)
  File "/home/mp/.config/blender/2.91/scripts/addons/MeasureIt_ARCH/measureit_arch_geometry.py", line 353, in draw_hatches
    polys = z_order_faces(polys,myobj)
  File "/home/mp/.config/blender/2.91/scripts/addons/MeasureIt_ARCH/measureit_arch_geometry.py", line 3556, in z_order_faces
    idx = sort_camera_z_faces(face,ordered_face_list,obj)
  File "/home/mp/.config/blender/2.91/scripts/addons/MeasureIt_ARCH/measureit_arch_geometry.py", line 3563, in sort_camera_z_faces
    check_z = get_camera_z_dist(obj.matrix_world @ ordered_list[idx].calc_center_median())
AttributeError: 'MeshPolygon' object has no attribute 'calc_center_median'

location: <unknown location>:-1
```