### PR TITLE
Add default styles on Blend load when no style is defined yet

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -211,6 +211,7 @@ def register():
         bpy.utils.register_class(cls)
 
     bpy.app.handlers.load_post.append(measureit_arch_main.load_handler)
+    bpy.app.handlers.load_post.append(measureit_arch_styles.create_preset_styles)
     bpy.app.handlers.save_pre.append(measureit_arch_main.save_handler)
 
     # Register pointer properties

--- a/measureit_arch_annotations.py
+++ b/measureit_arch_annotations.py
@@ -62,8 +62,10 @@ def annotation_update_flag(self, context):
 
 
 def update_custom_props(self, context):
-    ignoredProps = ['AnnotationGenerator', 'DimensionGenerator',
-                    'LineGenerator', '_RNA_UI', 'cycles', 'cycles_visibility', 'obverts']
+    ignoredProps = [
+        'AnnotationGenerator', 'DimensionGenerator', 'LineGenerator',
+        '_RNA_UI', 'cycles', 'cycles_visibility', 'obverts'
+    ]
     idx = 0
     for key in context.object.keys():
         if key not in ignoredProps:
@@ -82,8 +84,7 @@ class CustomProperties(PropertyGroup):
 def custom_shape_poll(self, collection):
     myobj = self.annotationAnchorObject
     try:
-        # TODO: should this be collection.objects ?
-        col.objects[myobj.name]
+        collection.objects[myobj.name]
     except:
         return collection
 
@@ -122,7 +123,8 @@ class AnnotationProperties(BaseWithText, PropertyGroup):
 
     shape_to_text: BoolProperty(
         name='Shape to text',
-        description='Align the custom annotation shape with the annotation text, rather than the anchor point',
+        description='Align the custom annotation shape with the annotation text, '
+                    'rather than the anchor point',
         default=False)
 
     annotationRotation: FloatVectorProperty(
@@ -175,8 +177,9 @@ class AnnotationContainer(PropertyGroup):
     num_annotations: IntProperty(
         name='Number of Annotations', min=0, max=1000, default=0,
         description='Number total of Annotations')
-    active_index: IntProperty(name='Active Annotation Index',
-        update = update_active_annotation)
+    active_index: IntProperty(
+        name='Active Annotation Index',
+        update=update_active_annotation)
     show_annotation_settings: BoolProperty(
         name='Show Annotation Settings', default=False)
     show_annotation_fields: BoolProperty(
@@ -214,7 +217,7 @@ class AddAnnotationButton(Operator):
             if (bpy.context.mode == 'OBJECT' and
                 len(context.selected_objects) == 0):
                 cursorLoc = bpy.context.scene.cursor.location
-                newEmpty = bpy.ops.object.empty_add(
+                bpy.ops.object.empty_add(
                     type='SPHERE', radius=0.01, location=cursorLoc)
                 context.object.name = 'Annotation Empty'
                 emptyAnnoFlag = True
@@ -250,10 +253,9 @@ class AddAnnotationButton(Operator):
                     newAnnotation.textAlignment = 'C'
                     newAnnotation.lineWeight = 0
 
-                newAnnotation.name = (
-                    "Annotation " + str(annotationGen.num_annotations))
+                newAnnotation.name = "Annotation {}".format(annotationGen.num_annotations)
                 field = newAnnotation.textFields.add()
-                field.text = ("Annotation " + str(annotationGen.num_annotations))
+                field.text = ("Annotation {}".format(annotationGen.num_annotations))
                 field2 = newAnnotation.textFields.add()
                 field2.text = ("")
 
@@ -261,8 +263,7 @@ class AddAnnotationButton(Operator):
                 newAnnotation.fontSize = 24
             return {'FINISHED'}
         else:
-            self.report({'WARNING'},
-                        "View3D not found, cannot run operator")
+            self.report({'WARNING'}, "View3D not found, cannot run operator")
 
         return {'CANCELLED'}
 
@@ -279,8 +280,8 @@ class M_ARCH_UL_annotations_list(UIList):
             layout.use_property_decorate = False
             row = layout.row(align=True)
             subrow = row.row()
-            subrow.prop(annotation, "name", text="",
-                        emboss=False, icon='FONT_DATA')
+            subrow.prop(
+                annotation, "name", text="", emboss=False, icon='FONT_DATA')
 
             if annotation.visible:
                 visIcon = 'HIDE_OFF'
@@ -298,8 +299,9 @@ class M_ARCH_UL_annotations_list(UIList):
                 subrow.scale_x = 0.6
                 subrow.prop(annotation, 'color', text="")
             else:
-                row.prop_search(annotation, 'style', StyleGen,
-                                'annotations', text="", icon='COLOR')
+                row.prop_search(
+                    annotation, 'style', StyleGen, 'annotations',
+                    text="", icon='COLOR')
                 row.separator()
 
             if hasGen:
@@ -339,8 +341,9 @@ class OBJECT_PT_UIAnnotations(Panel):
                 row = layout.row()
 
                 # Draw The UI List
-                row.template_list("M_ARCH_UL_annotations_list", "", annoGen, "annotations",
-                                  annoGen, "active_index", rows=2, type='DEFAULT')
+                row.template_list(
+                    "M_ARCH_UL_annotations_list", "", annoGen, "annotations",
+                    annoGen, "active_index", rows=2, type='DEFAULT')
 
                 # Operators Next to List
                 col = row.column(align=True)
@@ -437,16 +440,19 @@ class OBJECT_PT_UIAnnotations(Panel):
                     row.label(text=annotation.name + ' Settings:')
 
                     if annoGen.show_annotation_settings:
-
                         col = box.column(align=True)
-                        col.prop_search(annotation, 'customShape',
-                                        bpy.data, 'collections', text='Custom Shape')
-                        col.prop(annotation, 'custom_shape_location',
-                                 text='Custom Shape Location')
-                        col.prop(annotation, 'custom_scale',
-                                 text='Custom Shape Scale')
-                        col.prop(annotation, 'custom_local_transforms',
-                                 text='Use Local Transforms')
+                        col.prop_search(
+                            annotation, 'customShape', bpy.data, 'collections',
+                            text='Custom Shape')
+                        col.prop(
+                            annotation, 'custom_shape_location',
+                            text='Custom Shape Location')
+                        col.prop(
+                            annotation, 'custom_scale',
+                            text='Custom Shape Scale')
+                        col.prop(
+                            annotation, 'custom_local_transforms',
+                            text='Use Local Transforms')
                         # col.prop(annotation, 'custom_fit_text', text = 'Fit Text')
 
                         if not annotation.uses_style:
@@ -465,22 +471,17 @@ class OBJECT_PT_UIAnnotations(Panel):
 
                             col = box.column(align=True)
                             col.prop(annotation, 'fontSize', text="Font Size")
-                            col.prop(annotation, 'textAlignment',
-                                     text='Justification')
-                            col.prop(annotation, 'textPosition',
-                                     text='Position')
+                            col.prop(annotation, 'textAlignment', text='Justification')
+                            col.prop(annotation, 'textPosition', text='Position')
 
                             col = box.column(align=True)
                             col.prop(annotation, 'endcapA', text='End Cap')
                             col.prop(annotation, 'endcapSize', text='Size')
-                            col.prop(annotation, 'endcapArrowAngle',
-                                     text='Arrow Angle')
+                            col.prop(annotation, 'endcapArrowAngle', text='Arrow Angle')
 
                             col = box.column(align=True)
-                            col.prop(annotation, 'lineWeight',
-                                     text="Line Weight")
-                            col.prop(annotation, 'draw_leader',
-                                     text='Draw Leader')
+                            col.prop(annotation, 'lineWeight', text="Line Weight")
+                            col.prop(annotation, 'draw_leader', text='Draw Leader')
 
                         col = box.column()
                         col.prop(annotation, 'leader_length')
@@ -522,16 +523,8 @@ class TranslateAnnotationOp(bpy.types.Operator):
     bl_options = {'GRAB_CURSOR', 'INTERNAL', 'BLOCKING', 'UNDO'}
 
     idx: IntProperty()
-
-    constrainAxis: BoolVectorProperty(
-        name="Constrain Axis",
-        size=3,
-        subtype='XYZ')
-
-    offset: FloatVectorProperty(
-        name="Offset",
-        size=3)
-
+    constrainAxis: BoolVectorProperty(name="Constrain Axis", size=3, subtype='XYZ')
+    offset: FloatVectorProperty(name="Offset", size=3)
     objIndex: IntProperty()
 
     def modal(self, context, event):
@@ -592,13 +585,15 @@ class TranslateAnnotationOp(bpy.types.Operator):
             context.area.header_text_set("Move " + axisText + "%.4f" % delta)
 
         elif event.type == 'LEFTMOUSE':
-            # Setting hide_viewport is a stupid hack to force Gizmos to update after operator completes
+            # Setting hide_viewport is a stupid hack to force Gizmos to update
+            # after operator completes
             context.object.hide_viewport = False
             context.area.header_text_set(None)
             return {'FINISHED'}
 
         elif event.type in {'RIGHTMOUSE', 'ESC'}:
-            # Setting hide_viewport is a stupid hack to force Gizmos to update after operator completes
+            # Setting hide_viewport is a stupid hack to force Gizmos to update
+            # after operator completes
             context.object.hide_viewport = False
             context.area.header_text_set(None)
             annotation.annotationOffset[0] = self.init_x

--- a/measureit_arch_dimensions.py
+++ b/measureit_arch_dimensions.py
@@ -222,8 +222,9 @@ class DimensionContainer(PropertyGroup):
     measureit_arch_num: IntProperty(
         name='Number of measures', min=0, max=1000, default=0,
         description='Total number of MeasureIt_Arch elements')
-    active_index: IntProperty(name="Active Dimension Index",
-                update = update_active_dim)
+    active_index: IntProperty(
+        name="Active Dimension Index",
+        update=update_active_dim)
     show_dimension_settings: BoolProperty(
         name='Show Dimension Settings', default=False)
 
@@ -292,8 +293,8 @@ class AddAlignedDimensionButton(Operator):
                 newDimension.dimPointA = p1['vert']
                 newDimension.dimPointB = p2['vert']
 
-                newDimension.name = 'Dimension ' + \
-                    str(len(DimGen.alignedDimensions))
+                newDimension.name = 'Dimension {}'.format(
+                    len(DimGen.alignedDimensions))
                 newDimensions.append(newDimension)
 
                 newWrapper = DimGen.wrapper.add()
@@ -456,8 +457,8 @@ class AddAxisDimensionButton(Operator):
                 newDimension.dimPointA = p1['vert']
                 newDimension.dimPointB = p2['vert']
 
-                newDimension.name = 'Dimension ' + \
-                    str(len(DimGen.axisDimensions))
+                newDimension.name = 'Dimension {}'.format(
+                    len(DimGen.axisDimensions))
                 newDimensions.append(newDimension)
 
                 newWrapper = DimGen.wrapper.add()
@@ -605,7 +606,8 @@ class AddAngleButton(Operator):
 
                 newDimension = DimGen.angleDimensions.add()
                 newDimension.itemType = 'angleDimensions'
-                newDimension.name = 'Angle ' + str(len(DimGen.angleDimensions))
+                newDimension.name = 'Angle {}'.format(
+                    len(DimGen.angleDimensions))
                 newWrapper = DimGen.wrapper.add()
                 newWrapper.itemType = 'angleDimensions'
                 recalc_dimWrapper_index(self, context)
@@ -669,7 +671,7 @@ class AddArcButton(Operator):
                 DimGen = mainobject.DimensionGenerator
                 newDimension = DimGen.arcDimensions.add()
                 newDimension.itemType = 'arcDimensions'
-                newDimension.name = 'Arc ' + str(len(DimGen.arcDimensions))
+                newDimension.name = 'Arc {}'.format(len(DimGen.arcDimensions))
                 newDimension.lineWeight = 2
                 newWrapper = DimGen.wrapper.add()
                 newWrapper.itemType = 'arcDimensions'

--- a/measureit_arch_geometry.py
+++ b/measureit_arch_geometry.py
@@ -33,10 +33,10 @@ import numpy as np
 import svgwrite
 import time
 
-from bpy_extras import view3d_utils, mesh_utils
+from bpy_extras import mesh_utils
 from datetime import datetime
 from gpu_extras.batch import batch_for_shader
-from math import fabs, degrees, radians, sqrt, sin, pi
+from math import fabs, degrees, radians, sin, pi
 from mathutils import Vector, Matrix, Euler, Quaternion
 from mathutils.geometry import area_tri
 from sys import getrecursionlimit, setrecursionlimit
@@ -2304,11 +2304,11 @@ def draw_annotation(context, myobj, annotationGen, mat, svg=None):
             if annotationProps.align_to_camera:
                 # Only use the z rot of the annotation rotation
                 annoMat = Matrix.Identity(3).copy()
-                annoEuler = Euler((0,0,0), 'XYZ')
+                annoEuler = Euler((0, 0, 0), 'XYZ')
                 annoMat.rotate(annoEuler)
                 annoMat = rotMat.to_4x4()
 
-                #use Camera rot for the rest
+                # use Camera rot for the rest
                 camera = context.scene.camera
                 cameraMat = camera.matrix_world
                 cameraRot = cameraMat.decompose()[1]
@@ -2318,7 +2318,7 @@ def draw_annotation(context, myobj, annotationGen, mat, svg=None):
 
                 fullRotMat = cameraRotMat
 
-                cameraX = cameraRotMat @ Vector((1,0,0))
+                cameraX = cameraRotMat @ Vector((1, 0, 0))
                 leader1 = p1 - p2
                 proj = leader1.dot(cameraX)
                 if proj > 0:
@@ -2406,10 +2406,10 @@ def draw_annotation(context, myobj, annotationGen, mat, svg=None):
             for textField in fields:
                 set_text(textField, myobj)
                 origin = p3
-                xDir = fullRotMat @ Vector((1*mult, 0, 0))
+                xDir = fullRotMat @ Vector((1 * mult, 0, 0))
                 yDir = fullRotMat @ Vector((0, 1, 0))
 
-                #draw_lines(1,(0,1,0,1),[(0,0,0),xDir,(0,0,0),yDir])
+                # draw_lines(1,(0,1,0,1),[(0,0,0),xDir,(0,0,0),yDir])
 
                 textcard = generate_text_card(
                     context, textField, annotationProps, basePoint=origin, xDir=xDir, yDir=yDir, cardIdx=fieldIdx)
@@ -2436,7 +2436,6 @@ def draw_annotation(context, myobj, annotationGen, mat, svg=None):
                 coords.append(p3)
 
                 textcard = fields[0]['textcard']
-
 
                 if not annotationProps.draw_leader:
                     coords = []
@@ -2505,7 +2504,7 @@ def set_text(textField, obj):
             if view is not None:
                 textField.text = view.name
 
-        #NOTES, (actually we set this in the draw annotation code since it needs to spawn new texfields)
+        # NOTES, (actually we set this in the draw annotation code since it needs to spawn new texfields)
         elif textField.textSource == 'NOTES':
             textField.text = ''
 
@@ -2781,7 +2780,7 @@ def generate_end_caps(context, item, capType, capSize, pos, userOffsetVector, mi
 
         # Define Overextension
         capCoords.append(pos)
-        capCoords.append(line* capSize + pos)
+        capCoords.append(line * capSize + pos)
 
         # Define Square
         x = distVector.normalized() * capSize
@@ -3086,7 +3085,7 @@ def check_vis(item, props):
     context = bpy.context
     inView = False
     if (props.visibleInView == "" or
-        props.visibleInView == context.window.view_layer.name):
+            props.visibleInView == context.window.view_layer.name):
         inView = True
 
     if item.visible and props.visible and inView:
@@ -3304,7 +3303,7 @@ def get_resolution():
 
     if (view is not None and
         view.camera is not None and
-        view.res_type == 'res_type_paper'):
+            view.res_type == 'res_type_paper'):
         return view.res
 
     return sceneProps.default_resolution

--- a/measureit_arch_main.py
+++ b/measureit_arch_main.py
@@ -26,7 +26,6 @@
 import bpy
 import bgl
 
-from bmesh import from_edit_mesh
 from bpy.types import Panel, Operator, SpaceView3D
 from bpy.app.handlers import persistent
 from mathutils import Vector, Matrix
@@ -224,7 +223,6 @@ class MEASUREIT_PT_main_panel(Panel):
                             StyleGen, 'annotations', text="", icon='COLOR')
 
 
-
 class OBJECT_PT_Panel(Panel):
     """ Panel in the object properties window """
     bl_idname = 'OBJECT_PT_Panel'
@@ -235,6 +233,7 @@ class OBJECT_PT_Panel(Panel):
 
     def draw(self, context):
         pass
+
 
 class SCENE_PT_Panel(bpy.types.Panel):
     """ Main (scene) properties panel """
@@ -291,6 +290,7 @@ class SCENE_PT_MARCH_Settings(Panel):
         if sceneProps.enable_experimental:
             col.prop(sceneProps, "instance_dims")
         # col.prop(sceneProps, "debug_flip_text")
+
 
 class ShowHideViewportButton(Operator):
     """ A button that enables/disables Viewport Display """
@@ -486,8 +486,9 @@ def text_update_loop(context, objlist):
                         for textField in view.textFields:
                             fields.append(textField)
 
-                    update_text(textobj=annotation,
-                                props=annotationProps, context=context, fields = fields)
+                    update_text(
+                        textobj=annotation, props=annotationProps,
+                        context=context, fields=fields)
 
                 # Draw Instanced Objects
 

--- a/measureit_arch_schedules.py
+++ b/measureit_arch_schedules.py
@@ -15,7 +15,6 @@ from bpy.types import (
     PropertyGroup,
     Panel,
     Operator,
-    Scene,
     UIList,
     Collection
 )
@@ -23,8 +22,8 @@ from datetime import datetime
 
 from .measureit_arch_units import format_distance
 
-class ColumnProps(PropertyGroup):
 
+class ColumnProps(PropertyGroup):
     name: StringProperty()
 
     data_path: StringProperty(
@@ -71,7 +70,6 @@ class ScheduleProperties(PropertyGroup):
     collection: PointerProperty(type=Collection)
 
     columns: CollectionProperty(type=ColumnProps)
-
 
 
 class ScheduleContainer(PropertyGroup):
@@ -317,8 +315,6 @@ class DuplicateScheduleButton(Operator):
 
 class M_ARCH_UL_Schedules_list(UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname):
-        scene = bpy.context.scene
-
         if self.layout_type in {'DEFAULT', 'COMPACT'}:
             schedule = item
             layout.use_property_decorate = False
@@ -441,10 +437,9 @@ class SCENE_MT_Schedules_menu(bpy.types.Menu):
 
     def draw(self, context):
         layout = self.layout
-        scene = context.scene
-
-        op = layout.operator('measureit_arch.duplicateschedulebutton',
-                             text="Duplicate Selected Schedule", icon='DUPLICATE')
+        layout.operator(
+            'measureit_arch.duplicateschedulebutton',
+            text="Duplicate Selected Schedule", icon='DUPLICATE')
 
 
 class AddScheduleButton(Operator):

--- a/measureit_arch_sheets.py
+++ b/measureit_arch_sheets.py
@@ -31,7 +31,6 @@ from bpy.props import IntProperty, CollectionProperty, FloatVectorProperty, \
     BoolProperty, StringProperty, PointerProperty
 
 
-
 class SheetViewProperties(PropertyGroup):
 
     rotation: FloatVectorProperty(
@@ -104,8 +103,6 @@ class DeleteSheetViewButton(Operator):
 
 class M_ARCH_UL_Sheets_list(UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname):
-        scene = bpy.context.scene
-
         if self.layout_type in {'DEFAULT', 'COMPACT'}:
             view = item
             layout.use_property_decorate = False
@@ -144,7 +141,6 @@ class SCENE_PT_Sheet(Panel):
         layout.use_property_split = True
         layout.use_property_decorate = False
 
-        scene = context.scene
         SheetGen = context.object.SheetGenerator
 
         row = layout.row()

--- a/measureit_arch_styles.py
+++ b/measureit_arch_styles.py
@@ -424,7 +424,8 @@ def draw_line_style_row(line, layout):
 def draw_line_style_settings(line, layout):
     col = layout.column()
     col.prop_search(
-        line, 'visibleInView', bpy.context.scene, 'view_layers', text='Visible In View')
+        line, 'visibleInView', bpy.context.scene, 'view_layers',
+        text='Visible In View')
 
     col.prop(line, 'color', text="Color")
     col.prop(line, 'lineWeight', text="Lineweight")

--- a/measureit_arch_views.py
+++ b/measureit_arch_views.py
@@ -332,7 +332,6 @@ class ViewProperties(PropertyGroup):
         update=update)
 
 
-
 class ViewContainer(PropertyGroup):
     active_index: IntProperty(
         name='Active View Index', min=0, max=1000, default=0,
@@ -344,7 +343,6 @@ class ViewContainer(PropertyGroup):
 
     # Array of views
     views: CollectionProperty(type=ViewProperties)
-
 
 
 class DeleteViewButton(Operator):
@@ -401,13 +399,11 @@ class DuplicateViewButton(Operator):
 
 class M_ARCH_UL_Views_list(UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname):
-        scene = bpy.context.scene
-
         if self.layout_type in {'DEFAULT', 'COMPACT'}:
             view = item
             layout.use_property_decorate = False
             row = layout.row(align=True)
-            split = row.split(factor = 0.3)
+            split = row.split(factor=0.3)
             split.prop(view, "view_num", text="", emboss=False, icon='DOCUMENTS')
             split.prop(view, "name", text="", emboss=False)
             row.prop(view, 'camera', text="", icon='CAMERA_DATA')
@@ -452,7 +448,6 @@ class SCENE_PT_Views(Panel):
 
         col.separator()
         col.menu("SCENE_MT_Views_menu", icon='DOWNARROW_HLT', text="")
-
 
         if len(ViewGen.views) > 0 and ViewGen.active_index < len(ViewGen.views):
             view = ViewGen.views[ViewGen.active_index]
@@ -567,7 +562,6 @@ class SCENE_PT_Views(Panel):
                     row.prop(view, 'start_frame', text="Frame Range")
                     row.prop(view, 'end_frame', text="")
 
-
             # Notes below Settings
             if ViewGen.show_text_fields:
                 fieldsIcon = 'DISCLOSURE_TRI_DOWN'
@@ -578,7 +572,7 @@ class SCENE_PT_Views(Panel):
             col = box.column()
             row = col.row(align=True)
             row.prop(ViewGen, 'show_text_fields',
-                        text="", icon=fieldsIcon, emboss=False)
+                     text="", icon=fieldsIcon, emboss=False)
             row.label(text=view.name + ' Notes:')
 
             row.emboss = 'PULLDOWN_MENU'
@@ -608,7 +602,7 @@ class SCENE_PT_Views(Panel):
 
                     row = split.row(align=True)
                     row.prop(textField, 'autoFillText',
-                                text="", icon="FILE_TEXT")
+                             text="", icon="FILE_TEXT")
 
                     if textField.autoFillText:
                         row.prop(textField, 'textSource', text="")
@@ -633,16 +627,14 @@ class SCENE_PT_Views(Panel):
                     idx += 1
 
 
-
 class SCENE_MT_Views_menu(bpy.types.Menu):
     bl_label = "Custom Menu"
 
     def draw(self, context):
         layout = self.layout
-        scene = context.scene
-
-        op = layout.operator('measureit_arch.duplicateviewbutton',
-                             text="Duplicate Selected View", icon='DUPLICATE')
+        layout.operator(
+            'measureit_arch.duplicateviewbutton',
+            text="Duplicate Selected View", icon='DUPLICATE')
 
 
 class AddViewButton(Operator):


### PR DESCRIPTION
This is the PR for issue #154.

There are still some issues (which already existed):
- Duplicate style names are possible, and may give some unexpected behavior. We should probably prevent this.
- In `measureit_arch_baseclass.py` the properties `default_dimension_style`, `default_annotation_style` and `default_line_style` are defined as `StringProperty`, couldn't we use `PointerProperty` or something like that?

Finally, of course we could add more default styles, but at least this makes it easier for people starting out with MeasureIt_Arch.